### PR TITLE
docs: update old features apiVersions and commands not working

### DIFF
--- a/eks-2/helm.md
+++ b/eks-2/helm.md
@@ -1074,14 +1074,14 @@ whchoi98:~/environment/helm-chart-demo $ curl --data-binary "@helm-chart-demo-0.
 S3에 정상적으로 Chartmuseum이 배포되었는지 확인합니다.
 
 ```
-aws s3 ls s3://${s3chartmuseumt}
+aws s3 ls s3://${s3chartmuseum}
 
 ```
 
 출력 결과 예제
 
 ```
-aws s3 ls s3://${s3chartmuseumt}
+aws s3 ls s3://${s3chartmuseum}
 2022-02-14 14:28:03       1400 helm-chart-demo-0.1.0.tgz
 ```
 

--- a/eks-security/iam_group.md
+++ b/eks-security/iam_group.md
@@ -220,7 +220,7 @@ kubernetes 사용자 DevUser 에게 development namespace 전체 액세스 권�
 ```
 cat << EOF | kubectl apply -f - -n development
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: dev-role
 rules:
@@ -253,7 +253,7 @@ rules:
       - "update"
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: dev-role-binding
 subjects:
@@ -272,7 +272,7 @@ kubernetes 사용자 InteUser 에게 development namespace 전체 액세스 권�
 ```
 cat << EOF | kubectl apply -f - -n integration
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: integ-role
 rules:
@@ -305,7 +305,7 @@ rules:
       - "update"
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: integ-role-binding
 subjects:
@@ -331,12 +331,12 @@ arn 그룹을 허용하거나 삭제하려면 kube-system 네임 스페이스 �
 eksctl create iamidentitymapping \
   --cluster eksworkshop \
   --arn arn:aws:iam::${ACCOUNT_ID}:role/k8sDev \
-  --username DevUser
+  --username dev-user
 
 eksctl create iamidentitymapping \
   --cluster eksworkshop \
   --arn arn:aws:iam::${ACCOUNT_ID}:role/k8sInteg \
-  --username IntUser
+  --username integ-user
 
 eksctl create iamidentitymapping \
   --cluster eksworkshop \
@@ -418,14 +418,14 @@ EoF
 이제 만들어진 계정으로 전환하면서, 계정, 권한 ,역할 등을 점검해 봅니다.
 
 ```
-export KUBECONFIG=/tmp/kubeconfig-dev && eksctl utils write-kubeconfig eksworkshop
+export KUBECONFIG=/tmp/kubeconfig-dev && eksctl utils write-kubeconfig --cluster eksworkshop
 cat $KUBECONFIG | yq e '.users.[].user.exec.args += ["--profile", "dev"]' - -- | sed 's/eksworkshop./eksworkshop-dev./g' | sponge $KUBECONFIG
 
 ```
 
 ```
 aws sts get-caller-identity --profile dev
-kubectl run --generator=run-pod/v1 nginx-dev --image=nginx -n development
+kubectl run nginx-dev --image=nginx -n development
 kubectl get pods -n development
 
 ```

--- a/eks-storage/stateful-container.md
+++ b/eks-storage/stateful-container.md
@@ -334,7 +334,7 @@ EOF
 
 ```text
 kubectl -n mysql run mysql-client --image=mysql:5.7 -it --rm --restart=Never --\
->   mysql -h mysql-read -e "SELECT * FROM test.messages"
+   mysql -h mysql-read -e "SELECT * FROM test.messages"
 
 ```
 

--- a/observability/efk-logging.md
+++ b/observability/efk-logging.md
@@ -165,7 +165,7 @@ Events:              <none>
 export ES_DOMAIN_NAME="eksworkshop-logging"
 
 # Elasticsearch version
-export ES_VERSION="7.4"
+export ES_VERSION="OpenSearch_1.0"
 
 # kibana admin user
 export ES_DOMAIN_USER="eksworkshop"
@@ -187,7 +187,7 @@ curl -sS https://www.eksworkshop.com/intermediate/230_logging/deploy.files/es_do
   | envsubst > ~/environment/logging/es_domain.json
 
 # Create the cluster
-aws es create-elasticsearch-domain \
+aws opensearch create-domain \
   --cli-input-json  file://~/environment/logging/es_domain.json
 
 ```


### PR DESCRIPTION
실습해 보면서 작동을 안하거나 out dated 된 내용들을 수정했습니다.

1. apiVersion :  v1beta1 --> v1
2. ElasticSearch version : ES_VERSION="7.4" --> ES_VERSION="OpenSearch_1.0"
3. IAM 그룹 기반 관리 : RoleBinding의 UserName과 aws-auth의 UserName이 상이함, DevUser --> dev-user, IntUser --> nteg-user